### PR TITLE
feat: improve deep link handling and navigation

### DIFF
--- a/lib/widgets/account_screen/account_model.dart
+++ b/lib/widgets/account_screen/account_model.dart
@@ -148,20 +148,13 @@ class AccountModel extends ChangeNotifier {
 
   Future<void> _handleAuthDeepLink(String requestToken, BuildContext context) async {
     try {
-      // Uri? initialUri = await getInitialUri();
-      // if (initialUri != null) {
-      //   _handleAuthDeepLink(initialUri);
-      // }
       final appLinks = AppLinks();
       _sub = appLinks.uriLinkStream.listen((Uri? uri) async {
         if (uri != null) {
-          if(uri.path == '/auth_approve') {
+          if(uri.path == MainNavigationRouteNames.authApprove) {
             final authData = await _apiClientAuth.createAccessToken(requestToken: requestToken);
             final accountId = authData.accountId;
             final accessToken = authData.accessToken;
-            if (context.mounted) {
-              Navigator.canPop(context);
-            }
             _sub?.cancel();
             if(accountId != null && accessToken != null) {
               await SessionDataProvider.setAccessToken(accessToken);

--- a/lib/widgets/main_screen/main_screen_widget.dart
+++ b/lib/widgets/main_screen/main_screen_widget.dart
@@ -8,7 +8,6 @@ import 'package:the_movie_app/widgets/home_screen/home_widget.dart';
 import 'package:the_movie_app/widgets/main_screen/filter_widget.dart';
 import 'package:the_movie_app/widgets/movie_screens/movie_list_screen/movie_list_model.dart';
 import 'package:the_movie_app/widgets/movie_screens/movie_list_screen/movie_list_widget.dart';
-import 'package:the_movie_app/widgets/my_app/my_app_model.dart';
 import 'package:the_movie_app/widgets/tv_show_screens/tv_show_list_screen/tv_show_list_model.dart';
 import 'package:the_movie_app/widgets/tv_show_screens/tv_show_list_screen/tv_show_list_widget.dart';
 
@@ -26,7 +25,6 @@ class _MainScreenWidgetState extends State<MainScreenWidget> {
   final accountModel = AccountModel();
   int _selectedTab = 0;
   bool isSearchOpen = false;
-  Locale? _locale;
 
   void onSelectTab(int index) {
     if (_selectedTab == index) {
@@ -49,7 +47,6 @@ class _MainScreenWidgetState extends State<MainScreenWidget> {
   @override
   void initState() {
     super.initState();
-    _locale = Provider.read<MyAppModel>(context)?.locale;
     accountModel.checkLoginStatus();
     accountModel.checkLinkingStatus();
     movieListModel.loadContent();

--- a/lib/widgets/navigation/main_navigation.dart
+++ b/lib/widgets/navigation/main_navigation.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:the_movie_app/domain/entity/media/media_details/media_details.dart';
 import 'package:the_movie_app/domain/entity/person/credits_people/credits.dart';
 import 'package:the_movie_app/provider/provider.dart';
 import 'package:the_movie_app/widgets/ai_feature_screen/ai_feature_start_sreen/ai_feature_start_model.dart';
@@ -57,6 +56,7 @@ abstract class MainNavigationRouteNames {
   static const aiRecommendationByGenre = "/ai_recommendation_by_genre";
   static const aiRecommendationList = "/ai_recommendation_list";
   static const aiRecommendationByDescription = "/ai_recommendation_by_description";
+  static const authApprove = "/auth_approve";
 }
 
 class MainNavigation {
@@ -64,7 +64,7 @@ class MainNavigation {
     MainNavigationRouteNames.mainScreen : (context) => const MainScreenWidget(),
   };
 
-  Route<Object> onGenerateRoute(RouteSettings settings) {
+  Route<Object>? onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
       case MainNavigationRouteNames.movieDetails:
         final arguments = settings.arguments;
@@ -192,7 +192,6 @@ class MainNavigation {
 
       case MainNavigationRouteNames.homeSearch:
         final arguments = settings.arguments;
-        // final searchController = arguments is TextEditingController ? arguments : TextEditingController();
         final args = arguments is Map ? arguments : {};
         final searchController = args["searchController"];
         final index = args["index"];
@@ -239,6 +238,9 @@ class MainNavigation {
               ),
               child: const AiRecommendationListScreenWidget()),
         );
+
+      case MainNavigationRouteNames.authApprove:
+        return null;
 
       default:
         const widget = Text('Navigation error!!!');


### PR DESCRIPTION
- Updated the deep link handling in `AccountModel` to check for `/auth_approve` path using `MainNavigationRouteNames.authApprove` constant.
- Removed redundant check `Navigator.canPop(context)` in `_handleAuthDeepLink`.
- Removed unused `_locale` variable from `MainScreenWidget`.
- Updated `onGenerateRoute` function in `MainNavigation` to accept `null` as return value.
- Added `authApprove` route to `MainNavigationRouteNames`.
- Updated the onGenerateRoute to add handler for `authApprove`.
- Refactored code to remove commented blocks.